### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First, define some CSS that describes your animation.
   transform: translateY(50px);
 }
 
-.fade-enter.fade-enter-active) {
+.fade-enter.fade-enter-active {
   transition: opacity 250ms ease-in;
   opacity: 1;
 }


### PR DESCRIPTION
Removed typo in css demo code. 
Noticed it when copying and pasting the demo code and seeing a compilation error in webpack.